### PR TITLE
Replace hero GIF with CSS pixel art scene

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Logan Thorneloe</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <main class="page">
+    <figure class="hero">
+      <div
+        class="pixel-scene"
+        role="img"
+        aria-label="Pixel art of Logan working at a desk with snacks, drinks, music, a plant, and a bookshelf lit by a vertical light bar."
+      >
+        <div class="bookshelf"></div>
+        <div class="light-bar"></div>
+        <div class="plant">
+          <div class="pot"></div>
+          <div class="leaf leaf-one"></div>
+          <div class="leaf leaf-two"></div>
+          <div class="leaf leaf-three"></div>
+        </div>
+        <div class="desk">
+          <div class="top"></div>
+          <div class="front"></div>
+          <div class="keyboard"></div>
+          <div class="snack"></div>
+          <div class="drink"></div>
+        </div>
+        <div class="monitor">
+          <div class="screen"></div>
+          <div class="stand"></div>
+          <div class="base"></div>
+        </div>
+        <div class="logan">
+          <div class="torso"></div>
+          <div class="arm"></div>
+          <div class="head"></div>
+          <div class="hair"></div>
+          <div class="ear"></div>
+          <div class="headphones"></div>
+        </div>
+        <div class="chair"></div>
+        <div class="music-notes"></div>
+      </div>
+    </figure>
+    <section class="content">
+      <p>
+        Hey, I’m Logan—a developer who spends far too many late nights crafting delightful tools, sipping cold brew, and chasing that next spark of inspiration from this little office nook.
+      </p>
+      <ul class="highlights">
+        <li>Building friendly interfaces that feel like home.</li>
+        <li>Mixing code, coffee, and pixel art experiments.</li>
+        <li>Always curating playlists to soundtrack the workday.</li>
+      </ul>
+      <nav class="social-links" aria-label="Social links">
+        <a href="https://github.com/placeholder" target="_blank" rel="noopener noreferrer">GitHub</a>
+        <span aria-hidden="true">/</span>
+        <a href="https://www.linkedin.com/in/placeholder" target="_blank" rel="noopener noreferrer">LinkedIn</a>
+        <span aria-hidden="true">/</span>
+        <a href="mailto:hello@example.com">Email</a>
+        <span aria-hidden="true">/</span>
+        <a href="https://twitter.com/placeholder" target="_blank" rel="noopener noreferrer">Twitter</a>
+      </nav>
+    </section>
+  </main>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,629 @@
+:root {
+  color-scheme: dark;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2.5rem 1.5rem;
+  background-color: #0D121F;
+  color: #F5F5DC;
+  font-family: 'Fira Code', 'Courier New', Courier, monospace;
+}
+
+.page {
+  width: min(100%, 640px);
+  text-align: center;
+}
+
+.hero {
+  margin: 0 0 2rem;
+}
+
+
+.pixel-scene {
+  --px: min(0.8vmin, 6px);
+  position: relative;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  border-radius: 12px;
+  border: 2px solid rgba(245, 245, 220, 0.2);
+  background: linear-gradient(to top, #080c15 0 34%, #141c2f 34% 100%);
+  box-shadow: 0 0 30px rgba(13, 18, 31, 0.6), 0 0 12px rgba(84, 160, 255, 0.35);
+  overflow: hidden;
+  isolation: isolate;
+}
+
+.pixel-scene::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: repeating-linear-gradient(
+    to bottom,
+    rgba(12, 18, 31, 0) 0 calc(var(--px) * 1.6),
+    rgba(140, 201, 255, 0.05) calc(var(--px) * 1.6) calc(var(--px) * 1.9)
+  );
+  mix-blend-mode: screen;
+  opacity: 0.35;
+}
+
+.pixel-scene::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 50% 120%, rgba(84, 160, 255, 0.18), transparent 65%);
+  pointer-events: none;
+}
+
+.pixel-scene > * {
+  position: absolute;
+}
+
+.bookshelf {
+  left: calc(var(--px) * 3);
+  bottom: calc(var(--px) * 8);
+  width: calc(var(--px) * 11);
+  height: calc(var(--px) * 20);
+  background: #202f54;
+  border: calc(var(--px) * 0.6) solid #121a31;
+  border-radius: calc(var(--px) * 0.8);
+  box-shadow: inset 0 calc(var(--px) * -0.8) 0 rgba(0, 0, 0, 0.5), inset 0 calc(var(--px) * 0.8) 0 rgba(255, 255, 255, 0.05);
+}
+
+.bookshelf::before {
+  content: "";
+  position: absolute;
+  left: calc(var(--px) * 1);
+  right: calc(var(--px) * 1);
+  top: calc(var(--px) * 3);
+  height: calc(var(--px) * 1.2);
+  background: #151d33;
+  box-shadow: 0 calc(var(--px) * 4.4) 0 #151d33, 0 calc(var(--px) * 8.8) 0 #151d33;
+}
+
+.bookshelf::after {
+  content: "";
+  position: absolute;
+  left: calc(var(--px) * 1.2);
+  right: calc(var(--px) * 1.2);
+  top: calc(var(--px) * 1.4);
+  bottom: calc(var(--px) * 1.4);
+  background: linear-gradient(
+    to right,
+    #f2c94c 0 10%,
+    transparent 10% 14%,
+    #6fcf97 14% 24%,
+    transparent 24% 28%,
+    #eb5757 28% 38%,
+    transparent 38% 42%,
+    #56ccf2 42% 52%,
+    transparent 52% 56%,
+    #bb6bd9 56% 66%,
+    transparent 66% 70%,
+    #f2994a 70% 80%,
+    transparent 80% 100%
+  );
+  background-size: 100% calc(var(--px) * 6);
+  background-repeat: repeat-y;
+  opacity: 0.85;
+}
+
+.light-bar {
+  left: calc(var(--px) * 15);
+  bottom: calc(var(--px) * 8);
+  width: calc(var(--px) * 1.5);
+  height: calc(var(--px) * 18);
+  background: linear-gradient(to top, rgba(118, 171, 255, 0.85), rgba(46, 96, 200, 0.25));
+  border-radius: calc(var(--px) * 1);
+  box-shadow: 0 0 calc(var(--px) * 4) rgba(118, 171, 255, 0.65);
+  animation: pulse 4s ease-in-out infinite;
+}
+
+.plant {
+  right: calc(var(--px) * 3.5);
+  bottom: calc(var(--px) * 8);
+  width: calc(var(--px) * 12);
+  height: calc(var(--px) * 22);
+  z-index: 1;
+}
+
+.plant .pot {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  width: calc(var(--px) * 7.2);
+  height: calc(var(--px) * 5.2);
+  transform: translateX(-50%);
+  background: linear-gradient(to top, #422c1a, #704422);
+  border-radius: calc(var(--px) * 0.8);
+  box-shadow: inset 0 calc(var(--px) * 0.8) 0 rgba(0, 0, 0, 0.25);
+}
+
+.plant .pot::after {
+  content: "";
+  position: absolute;
+  top: calc(var(--px) * -1.1);
+  left: calc(var(--px) * -0.5);
+  width: calc(var(--px) * 8.2);
+  height: calc(var(--px) * 1.5);
+  background: linear-gradient(to right, #8b5930, #b7743c);
+  border-radius: calc(var(--px) * 1);
+}
+
+.plant .leaf {
+  position: absolute;
+  bottom: calc(var(--px) * 4);
+  width: calc(var(--px) * 9);
+  height: calc(var(--px) * 9);
+  background: radial-gradient(circle at 30% 30%, #a6f3a0, #3f8f4e 70%);
+  border-radius: 50%;
+  filter: saturate(85%);
+  opacity: 0.9;
+}
+
+.plant .leaf-one {
+  left: 0;
+  transform: rotate(-16deg);
+}
+
+.plant .leaf-two {
+  right: 0;
+  transform: rotate(20deg);
+}
+
+.plant .leaf-three {
+  left: 50%;
+  bottom: calc(var(--px) * 7);
+  width: calc(var(--px) * 7);
+  height: calc(var(--px) * 7);
+  transform: translateX(-50%) rotate(8deg);
+}
+
+.desk {
+  left: calc(var(--px) * 7);
+  right: calc(var(--px) * 7);
+  bottom: calc(var(--px) * 6);
+  height: calc(var(--px) * 10);
+  z-index: 2;
+}
+
+.desk .top {
+  position: absolute;
+  top: 0;
+  left: calc(var(--px) * -1);
+  right: calc(var(--px) * -1);
+  height: calc(var(--px) * 2.2);
+  background: linear-gradient(to right, #2b3656, #1f2740);
+  border-radius: calc(var(--px) * 1.2);
+  box-shadow: 0 calc(var(--px) * 1.2) 0 rgba(0, 0, 0, 0.6);
+}
+
+.desk .front {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: calc(var(--px) * 7.5);
+  background: linear-gradient(to top, #0f1626, #1b2440);
+  border-radius: 0 0 calc(var(--px) * 1) calc(var(--px) * 1);
+  box-shadow: inset 0 calc(var(--px) * 0.8) 0 rgba(255, 255, 255, 0.05);
+}
+
+.desk .keyboard,
+.desk .snack,
+.desk .drink {
+  position: absolute;
+}
+
+.desk .keyboard {
+  top: calc(var(--px) * 0.4);
+  left: 50%;
+  width: calc(var(--px) * 12);
+  height: calc(var(--px) * 1.7);
+  transform: translateX(-50%);
+  background: linear-gradient(to right, #1a2338, #283655);
+  border-radius: calc(var(--px) * 0.6);
+  box-shadow: 0 calc(var(--px) * 0.6) 0 rgba(0, 0, 0, 0.35);
+}
+
+.desk .keyboard::after {
+  content: "";
+  position: absolute;
+  inset: calc(var(--px) * 0.3);
+  background: repeating-linear-gradient(
+    to right,
+    rgba(245, 245, 220, 0.15) 0 calc(var(--px) * 0.9),
+    transparent calc(var(--px) * 0.9) calc(var(--px) * 1.2)
+  );
+  opacity: 0.6;
+}
+
+.desk .snack {
+  top: calc(var(--px) * 0.8);
+  left: calc(var(--px) * 1.5);
+  width: calc(var(--px) * 2.6);
+  height: calc(var(--px) * 1.8);
+  background: linear-gradient(to bottom, #f2a365, #e97c40);
+  border-radius: calc(var(--px) * 0.5);
+  box-shadow: 0 calc(var(--px) * 0.5) 0 rgba(0, 0, 0, 0.35);
+}
+
+.desk .snack::after {
+  content: "";
+  position: absolute;
+  inset: calc(var(--px) * 0.3);
+  border-radius: inherit;
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.desk .drink {
+  top: calc(var(--px) * 0.4);
+  right: calc(var(--px) * 1.6);
+  width: calc(var(--px) * 2.2);
+  height: calc(var(--px) * 3.6);
+  background: linear-gradient(to top, rgba(64, 110, 204, 0.65) 0 60%, rgba(169, 206, 255, 0.85) 60% 100%);
+  border-radius: calc(var(--px) * 0.7);
+  box-shadow: 0 calc(var(--px) * 0.7) 0 rgba(0, 0, 0, 0.35);
+}
+
+.desk .drink::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border: calc(var(--px) * 0.25) solid rgba(245, 245, 220, 0.35);
+  border-radius: inherit;
+}
+
+.desk .drink::after {
+  content: "";
+  position: absolute;
+  right: calc(var(--px) * 0.4);
+  top: calc(var(--px) * -2.4);
+  width: calc(var(--px) * 0.6);
+  height: calc(var(--px) * 3.8);
+  background: linear-gradient(to bottom, #f2994a 0 55%, #eb5757 55% 100%);
+  border-radius: calc(var(--px) * 0.4);
+}
+
+.monitor {
+  left: 50%;
+  bottom: calc(var(--px) * 12.5);
+  width: calc(var(--px) * 18);
+  height: calc(var(--px) * 12);
+  transform: translateX(-50%);
+  z-index: 4;
+}
+
+.monitor .screen {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: calc(var(--px) * 9);
+  background:
+    radial-gradient(circle at 20% 30%, rgba(140, 201, 255, 0.25), transparent 65%),
+    linear-gradient(to bottom, #1f3a5f, #13223e);
+  border: calc(var(--px) * 0.9) solid #090f1a;
+  border-radius: calc(var(--px) * 1.2);
+  box-shadow: 0 0 calc(var(--px) * 3.5) rgba(132, 200, 255, 0.35);
+  overflow: hidden;
+}
+
+.monitor .screen::before {
+  content: "";
+  position: absolute;
+  inset: calc(var(--px) * -0.4);
+  background: repeating-linear-gradient(
+    to bottom,
+    rgba(140, 201, 255, 0.08) 0 calc(var(--px) * 0.8),
+    rgba(140, 201, 255, 0.02) calc(var(--px) * 0.8) calc(var(--px) * 1.6)
+  );
+  animation: scan 6s linear infinite;
+  opacity: 0.7;
+}
+
+.monitor .screen::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, transparent 0 55%, rgba(140, 201, 255, 0.2) 55% 75%, transparent 75%);
+  mix-blend-mode: screen;
+  animation: flicker 3.5s steps(4, end) infinite;
+}
+
+.monitor .stand {
+  position: absolute;
+  bottom: calc(var(--px) * 2.4);
+  left: 50%;
+  width: calc(var(--px) * 2.4);
+  height: calc(var(--px) * 3.4);
+  transform: translateX(-50%);
+  background: linear-gradient(to top, #0d1525, #1c2943);
+  border-radius: calc(var(--px) * 0.8);
+}
+
+.monitor .base {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  width: calc(var(--px) * 6);
+  height: calc(var(--px) * 1.1);
+  transform: translateX(-50%);
+  background: linear-gradient(to top, #090f1c, #1e2a44);
+  border-radius: calc(var(--px) * 0.7);
+}
+
+.logan {
+  left: 50%;
+  bottom: calc(var(--px) * 7.2);
+  width: calc(var(--px) * 11);
+  height: calc(var(--px) * 14);
+  transform: translateX(-38%);
+  z-index: 3;
+}
+
+.logan .torso {
+  position: absolute;
+  bottom: calc(var(--px) * 3);
+  left: 0;
+  width: calc(var(--px) * 10.6);
+  height: calc(var(--px) * 7.2);
+  background: linear-gradient(to right, #1f2f4d, #264066);
+  border-radius: calc(var(--px) * 2.4) calc(var(--px) * 2.4) calc(var(--px) * 1.2) calc(var(--px) * 1.2);
+  box-shadow: inset 0 calc(var(--px) * -0.7) 0 rgba(0, 0, 0, 0.45);
+}
+
+.logan .arm {
+  position: absolute;
+  left: calc(var(--px) * 1.2);
+  bottom: calc(var(--px) * 4.4);
+  width: calc(var(--px) * 8.2);
+  height: calc(var(--px) * 2.2);
+  background: linear-gradient(to right, #3a4f78, #4d6ba3);
+  border-radius: calc(var(--px) * 1.1);
+  transform-origin: left center;
+  animation: type 4s ease-in-out infinite alternate;
+}
+
+.logan .head {
+  position: absolute;
+  top: 0;
+  left: calc(var(--px) * 3.2);
+  width: calc(var(--px) * 4.6);
+  height: calc(var(--px) * 5);
+  background: linear-gradient(to bottom, #f1c79b, #d7a574);
+  border-radius: calc(var(--px) * 2.2);
+  box-shadow: 0 calc(var(--px) * 0.4) 0 rgba(0, 0, 0, 0.25);
+}
+
+.logan .hair {
+  position: absolute;
+  top: calc(var(--px) * -0.4);
+  left: calc(var(--px) * 2.4);
+  width: calc(var(--px) * 7);
+  height: calc(var(--px) * 4);
+  background: linear-gradient(to right, #3c2a18, #2b1c0f);
+  border-radius: calc(var(--px) * 2.6);
+}
+
+.logan .hair::after {
+  content: "";
+  position: absolute;
+  left: calc(var(--px) * 1.1);
+  bottom: calc(var(--px) * -1.4);
+  width: calc(var(--px) * 1.6);
+  height: calc(var(--px) * 2.6);
+  background: #352311;
+  border-radius: calc(var(--px) * 0.9);
+}
+
+.logan .ear {
+  position: absolute;
+  top: calc(var(--px) * 2);
+  left: calc(var(--px) * 2.6);
+  width: calc(var(--px) * 1.1);
+  height: calc(var(--px) * 1.6);
+  background: linear-gradient(to bottom, #e2b080, #c08a5c);
+  border-radius: 50%;
+}
+
+.logan .headphones {
+  position: absolute;
+  top: calc(var(--px) * 0.7);
+  left: calc(var(--px) * 1.9);
+  width: calc(var(--px) * 6.4);
+  height: calc(var(--px) * 5.4);
+  border: calc(var(--px) * 0.8) solid #1c283f;
+  border-radius: calc(var(--px) * 3.4);
+  box-shadow: 0 0 calc(var(--px) * 1.4) rgba(84, 160, 255, 0.3);
+}
+
+.chair {
+  left: 50%;
+  bottom: calc(var(--px) * 4.4);
+  width: calc(var(--px) * 11);
+  height: calc(var(--px) * 8.6);
+  transform: translateX(-42%);
+  background: linear-gradient(to bottom, #1d263e, #13192d);
+  border-radius: calc(var(--px) * 2);
+  box-shadow: inset 0 calc(var(--px) * 1.6) 0 rgba(255, 255, 255, 0.08);
+  z-index: 1;
+}
+
+.chair::after {
+  content: "";
+  position: absolute;
+  bottom: calc(var(--px) * -1.2);
+  left: 50%;
+  width: calc(var(--px) * 8);
+  height: calc(var(--px) * 1.2);
+  transform: translateX(-50%);
+  background: #0a0f1d;
+  border-radius: calc(var(--px) * 0.6);
+}
+
+.music-notes {
+  right: calc(var(--px) * 4);
+  top: calc(var(--px) * 4);
+  width: calc(var(--px) * 0.9);
+  height: calc(var(--px) * 0.9);
+  color: #8cc9ff;
+  animation: notes 6s ease-in-out infinite;
+  filter: drop-shadow(0 0 calc(var(--px) * 0.8) rgba(140, 201, 255, 0.6));
+}
+
+.music-notes::before,
+.music-notes::after {
+  content: "";
+  position: absolute;
+  background: currentColor;
+  border-radius: calc(var(--px) * 0.4);
+}
+
+.music-notes::before {
+  top: calc(var(--px) * -0.4);
+  left: 0;
+  width: calc(var(--px) * 0.6);
+  height: calc(var(--px) * 2.6);
+  box-shadow: calc(var(--px) * 1.8) calc(var(--px) * 0.6) 0 #ffd166;
+}
+
+.music-notes::after {
+  bottom: calc(var(--px) * -1.2);
+  left: calc(var(--px) * -0.2);
+  width: calc(var(--px) * 1.1);
+  height: calc(var(--px) * 1.1);
+  background: #8cc9ff;
+  box-shadow: calc(var(--px) * 1.9) calc(var(--px) * 1.2) 0 #ffd166, calc(var(--px) * -1.6) calc(var(--px) * 0.8) 0 #9de08b;
+}
+
+@keyframes flicker {
+  0%,
+  100% {
+    opacity: 0.3;
+  }
+
+  40% {
+    opacity: 0.15;
+  }
+
+  50% {
+    opacity: 0.4;
+  }
+
+  70% {
+    opacity: 0.22;
+  }
+}
+
+@keyframes scan {
+  0% {
+    transform: translateY(-10%);
+  }
+
+  100% {
+    transform: translateY(10%);
+  }
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 0.7;
+    box-shadow: 0 0 calc(var(--px) * 4) rgba(118, 171, 255, 0.6);
+  }
+
+  50% {
+    opacity: 0.4;
+    box-shadow: 0 0 calc(var(--px) * 2.5) rgba(118, 171, 255, 0.35);
+  }
+}
+
+@keyframes type {
+  0% {
+    transform: translateX(-2%) rotate(0deg);
+  }
+
+  100% {
+    transform: translateX(2%) rotate(3deg);
+  }
+}
+
+@keyframes notes {
+  0%,
+  100% {
+    transform: translateY(0);
+    opacity: 0.8;
+  }
+
+  50% {
+    transform: translateY(calc(var(--px) * -2));
+    opacity: 1;
+  }
+}
+
+.content p {
+  margin: 0 0 1.75rem;
+  line-height: 1.65;
+}
+
+.highlights {
+  list-style-position: inside;
+  margin: 0 auto 2rem;
+  padding: 0;
+  text-align: left;
+  display: inline-block;
+  max-width: 100%;
+  gap: 0.75rem;
+}
+
+.highlights li {
+  margin-bottom: 0.75rem;
+}
+
+.highlights li:last-child {
+  margin-bottom: 0;
+}
+
+.social-links {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-weight: 500;
+}
+
+.social-links a {
+  color: #F5F5DC;
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.social-links a:hover,
+.social-links a:focus {
+  color: #8cc9ff;
+}
+
+.social-links span {
+  opacity: 0.6;
+}
+
+@media (max-width: 640px) {
+  body {
+    padding: 2rem 1.25rem;
+  }
+
+  .page {
+    text-align: center;
+  }
+
+  .highlights {
+    text-align: left;
+  }
+}


### PR DESCRIPTION
## Summary
- replace the hero image with a semantic container for a CSS-drawn pixel office scene
- craft gradients and animations in CSS to depict the office setup, removing the need for binary assets
- drop the generated GIF asset so the page remains text-only

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d14e50be28832c975445191c07aea9